### PR TITLE
chore: upgrade guava from 29.0 to 30.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <git-repo-https-url>https://github.com/marccarre/${project.artifactId}.git</git-repo-https-url>
 
         <commons-cli-version>1.3.1</commons-cli-version>
-        <guava-version>29.0-jre</guava-version>
+        <guava-version>30.1.1-jre</guava-version>
         <woodstox-version>5.0.1</woodstox-version>
         <junit-version>4.13.1</junit-version>
 


### PR DESCRIPTION
... in order to fix CVE-2020-8908.
See also: https://github.com/advisories/GHSA-5mg8-w23w-74h3